### PR TITLE
add 'Prerequisites' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Plugin for [Oh My Fish][omf-link].
 
 Uses your IP address to determine your location and find relevant weather data anywhere in the world.
 
+## Prerequisites
+
+This plugin depends on [jq](https://stedolan.github.io/jq/). Version **1.5+**
+
 ## Install
 
 ```fish


### PR DESCRIPTION
By deafult on my Ubuntu aptitude install `jq` version 1.3

And I got errors like:

``` bash
error: Invalid character
.city?
     ^
1 compile error
contains: Key not specified
error: strftime is not defined
.dt | strftime("%d/%m")
```

So it's better to inform about dependencies
