### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/functions/weather.fetch.fish
+++ b/functions/weather.fetch.fish
@@ -18,19 +18,19 @@ end
 
 function __md5
   # Use GNU coreutils if available.
-  if available md5sum
+  if type -q md5sum
     echo $argv[1] | md5sum | cut -d ' ' -f 1
     return 0
   end
 
   # Use BSD md5 utility if available.
-  if available md5
+  if type -q md5
     md5 -q -s "$argv[1]"
     return 0
   end
 
   # Try using openssl.
-  if available openssl
+  if type -q openssl
     echo $argv[1] | openssl md5 -r | cut -d ' ' -f 1
     return 0
   end

--- a/functions/weather.fish
+++ b/functions/weather.fish
@@ -2,7 +2,7 @@ function weather -d "Displays weather info"
   set -l api_key (config weather --get api-key)
 
   # Check external dependent programs.
-  if not available jq
+  if not type -q jq
     echo "The jq program is required to parse weather data."
     echo "See https://stedolan.github.io/jq for details."
     return 1

--- a/test/weather.fish
+++ b/test/weather.fish
@@ -1,1 +1,1 @@
-test available weather
+test type -q weather


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
