### PR TITLE
Fix the jq version detection

### DIFF
--- a/functions/weather.fish
+++ b/functions/weather.fish
@@ -8,7 +8,7 @@ function weather -d "Displays weather info"
     return 1
   else
     set -l jq_version (jq --version 2>&1 | tr -dC '[:digit:].')
-    if math "jq_version<1.5" > /dev/null
+    if math "$jq_version<1.5" > /dev/null
       echo "jq version $jq_version detected"
       echo "You must have jq version 1.5 or newer installed to parse weather data."
       echo "You can download the latest version of jq from https://stedolan.github.io/jq."

--- a/functions/weather.fish
+++ b/functions/weather.fish
@@ -6,10 +6,14 @@ function weather -d "Displays weather info"
     echo "The jq program is required to parse weather data."
     echo "See https://stedolan.github.io/jq for details."
     return 1
-  else if math (jq --version | cut -d - -f 2)"<1.5" > /dev/null
-    echo "You must have jq version 1.5 or newer installed to parse weather data."
-    echo "You can download the latest version of jq from https://stedolan.github.io/jq."
-    return 1
+  else
+    set -l jq_version (jq --version 2>&1 | tr -dC '[:digit:].')
+    if math "jq_version<1.5" > /dev/null
+      echo "jq version $jq_version detected"
+      echo "You must have jq version 1.5 or newer installed to parse weather data."
+      echo "You can download the latest version of jq from https://stedolan.github.io/jq."
+      return 1
+    end
   end
 
   # Display help message.


### PR DESCRIPTION
This change checks both stdout and stderr for the jq version, and better
handles the fact that jq versions are not always consistent, sometimes
using a space as a delimiter, sometimes using a hyphen.

This fixes https://github.com/oh-my-fish/plugin-weather/issues/21