### PR TITLE
Modify weather function to use bc directly

### DIFF
--- a/functions/weather.fish
+++ b/functions/weather.fish
@@ -8,7 +8,7 @@ function weather -d "Displays weather info"
     return 1
   else
     set -l jq_version (jq --version 2>&1 | tr -dC '[:digit:].')
-    if math "$jq_version<1.5" > /dev/null
+    if test (echo "$jq_version < 1.5" | bc ) -eq 1 > /dev/null
       echo "jq version $jq_version detected"
       echo "You must have jq version 1.5 or newer installed to parse weather data."
       echo "You can download the latest version of jq from https://stedolan.github.io/jq."


### PR DESCRIPTION
The current version of fish, v2.7.1, supports floating point comparisons using the `math` function, but does not support floating point comparisons using `test`.

That is, this works:

```fish
fish --version ; math "1.3 < 1.5" ; and echo true ; or echo false
fish, version 2.7.1
1
true
```

But this does not work:

```fish
fish --version ; test 1.3 -lt 1.5 ; and echo true; or echo false                                                                                                                       Fri Nov 30 02:43:58 2018
fish, version 2.7.1
test returned eval errors:
        invalid integer '1.3'
false
```

A future release of fish will make significant changes to the `math` functionality, essentially replacing a fish script wrapper around bc with built-in `math` command (implemented in C/C++), which will be much faster. However, the new `math` code does not include numeric comparisons. Instead, we will need to use the `test` command, and `test` has been extended to support floating-point comparisons, in addition to the integer comparisons it supports now. 

Example with latest Git development HEAD:

`math` no longer supports numeric comparisons:
```fish
fish --version ; math '1.3 < 1.5' ; and echo true; or echo false
fish, version 2.7.1-1761-gf0aa63cc
math: Error: Missing operator
'1.3 < 1.5'
     ^
false
```

But `test` now works for floating-point numbers:
```fish
fish --version ; test 1.3 -lt 1.5 ; and echo true; or echo false
fish, version 2.7.1-1761-gf0aa63cc
true
```

Right now, the most portable way to implement this functionality so that it will work with fish v2.7.1 and older *AND* with planned future releases is to utilize the `bc` command directly. 