### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/weather.fetch.fish
+++ b/functions/weather.fetch.fish
@@ -8,7 +8,7 @@ function weather.fetch -d "Fetches data from a URL backed by a cache"
     end
   end
 
-  if not find /tmp/$md5.url -mmin +$cache_age > /dev/null ^ /dev/null
+  if not find /tmp/$md5.url -mmin +$cache_age > /dev/null 2> /dev/null
     curl -Gs $flags $argv[1] > /tmp/$md5.url
       or return 1
   end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618