### PR TITLE
Use documented API parameter

### DIFF
--- a/functions/weather.fish
+++ b/functions/weather.fish
@@ -31,13 +31,13 @@ function weather -d "Displays weather info"
     set location (weather.location)
 
     # Fetch weather data based on the location.
-    if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/weather" lat=$location[1] lon=$location[2] APPID=$api_key)
+    if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/weather" lat=$location[1] lon=$location[2] appid=$api_key)
       echo "Unable to fetch weather data; please try again later."
       return 1
     end
   else
     # Fetch weather based on a search query.
-    if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/weather" "q=$loc" APPID=$api_key)
+    if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/weather" "q=$loc" appid=$api_key)
       echo "Unable to fetch weather data; please try again later."
       return 1
     end

--- a/functions/weather.forecast.fish
+++ b/functions/weather.forecast.fish
@@ -1,7 +1,7 @@
 function weather.forecast -d "Displays weather forecast lines"
   set -l api_key (config weather --get api-key)
 
-  if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/forecast?lat=$argv[1]&lon=$argv[2]&APPID=$api_key")
+  if not set json (weather.fetch "http://api.openweathermap.org/data/2.5/forecast?lat=$argv[1]&lon=$argv[2]&appid=$api_key")
     echo "Unable to fetch weather data; please try again later."
     return 1
   end


### PR DESCRIPTION
I got the same error as in https://github.com/oh-my-fish/plugin-weather/issues/42

Changing the parameter to be lowercase, and using my own api key fixed this.

```
# create a key at https://home.openweathermap.org/api_keys
config weather --set api-key aabbccddee...
```