### PR TITLE
Switch geolocation API to freeip2geo provider

### DIFF
--- a/functions/weather.location.fish
+++ b/functions/weather.location.fish
@@ -6,7 +6,7 @@ function weather.location -d "Get the current geographic location"
   end
 
   # Fetch location data based on our IP
-  if not set geoip_data (weather.fetch "https://ipapi.com/ip_api.php?ip=$ip")
+  if not set geoip_data (weather.fetch "https://freeip2geo.net/api")
     echo "Unable to query GeoIP data; please try again later."
     return 1
   end

--- a/functions/weather.location.fish
+++ b/functions/weather.location.fish
@@ -1,10 +1,4 @@
 function weather.location -d "Get the current geographic location"
-  # Attempt to get our external IP address.
-  if not set ip (__weather_get_ip)
-    echo "No Internet connection or IP service unavailable."
-    return 1
-  end
-
   # Fetch location data based on our IP
   if not set geoip_data (weather.fetch "https://freeip2geo.net/api")
     echo "Unable to query GeoIP data; please try again later."
@@ -16,27 +10,4 @@ function weather.location -d "Get the current geographic location"
   echo $geoip_data | jq '.longitude'
   echo $geoip_data | jq -r '.city?'
   echo $geoip_data | jq -r '.country_name'
-end
-
-function __weather_get_ip -d "Get the current device's public IP address"
-  # Attempt to get our external IP using the OpenDNS resolver.
-  if type -q dig
-    if set -q __weather_system_dns
-      if set ip (dig +short myip.opendns.com 2>/dev/null)
-        echo $ip
-        return
-      end
-    else
-      if set ip (dig +short myip.opendns.com @resolver1.opendns.com 2>/dev/null)
-        echo $ip
-        return
-      end
-    end
-  end
-
-  # Attempt to get our external IP using a web service.
-  if set ip (weather.fetch "http://ipecho.net/plain")
-    echo $ip
-  end
-
 end


### PR DESCRIPTION
Switch geolocation provider to reduce initial setup steps.

ipapi [requires registration](https://ipapi.com/documentation#access_keys) to get API key, which is needed. https://github.com/oh-my-fish/plugin-weather/pull/47 adds the missing 
instructions for requesting a token and setting it in the config.

[freeIP2GEO](https://freeip2geo.net/#features) does not require registration. It doesn't take any parameters and assumes the caller's IP address. While this would not work correctly under VPN, I believe the existing `dig` command behaves the same and gets the public IP address at the exit side (someone please correct me!).